### PR TITLE
stack list-dependencies:  use --system-ghc

### DIFF
--- a/stack2nix/Main.hs
+++ b/stack2nix/Main.hs
@@ -8,6 +8,7 @@ args :: Parser Args
 args = Args
        <$> optional (strOption $ long "revision" <> help "revision to use when fetching from VCS")
        <*> optional (strOption $ short 'o' <> help "output file for generated nix expression")
+       <*> (flag False True $ long "system-ghc" <> help "pass --system-ghc to stack invocations")
        <*> strArgument (metavar "URI")
 
 main :: IO ()


### PR DESCRIPTION
Tested to generate a nix expression sufficiently good to start building `cardano-sl`.