### PR TITLE
Add Vagrant support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,23 @@
 
 ## Installation
 
-Other installation methods will be supported, but for now this is the
-recommended way.
+There are two options. The first is to install stack2nix and its dependencies on your machine directly, and the second is to use the supported virtual machine configuration.
+
+If there are difficulties please file an issue. Generally the virtual machine approach should be more reliable.
+
+### Native Environment
 
 1. Install [nix](https://nixos.org/nix/).
 2. Clone this repo.
-4. Run `stack install` to install.
-5. Ensure `cabal2nix` version 2.2.1 is in your PATH.
+3. Run `stack install` to install.
+4. Ensure `cabal2nix` v2.2.1 and `stack2nix` are in your `$PATH`.
+
+### Virtual Machine
+
+1. Install [VirtualBox](https://www.virtualbox.org/wiki/VirtualBox) and [Vagrant](https://www.vagrantup.com/).
+2. Clone this repo.
+3. Run `./scripts/vagrant.sh` and take a coffee break.
+4. If there are no errors, log into the VM: `vagrant ssh`.
 
 ## Usage
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# See ./scripts/vagrant.sh
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "8192"
+    vb.cpus = 2
+  end
+end

--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd "$DIR/.."
+vagrant up
+vagrant ssh -c "sudo mount -o remount,exec,size=4G,mode=755 /run/user"
+vagrant ssh -c "echo export PATH=\"\$PATH:\$HOME/.local/bin\" > \$HOME/.bash_profile"
+vagrant ssh -c "curl https://nixos.org/nix/install | sh"
+vagrant ssh -c "cd /vagrant && ./scripts/travis.sh"


### PR DESCRIPTION
The existing installation method is convenient when it works, but it
assumes certain things about the runtime environment. For now
encapsulating all that state/logic in a VM should improve
reproducibility, benefiting both users and developers who are testing
changes.