### PR TITLE
Better error tracing

### DIFF
--- a/src/Stack2nix.hs
+++ b/src/Stack2nix.hs
@@ -155,12 +155,12 @@ stack2nix args@Args{..} = do
 
 -- Credit: https://stackoverflow.com/a/18898822/204305
 mapPool :: T.Traversable t => Args -> (a -> IO b) -> t a -> IO (t b)
-mapPool Args{..} f xs = do
-  let max' = if argSerialise
-             then 1
-             else 4
-  sem <- new max'
-  mapConcurrently (with sem . f) xs
+mapPool Args{..} f xs =
+  if argSerialise
+    then  traverse f xs
+    else do
+    sem <- new 4
+    mapConcurrently (with sem . f) xs
 
 toNix :: Args -> Maybe String -> FilePath -> StackConfig -> IO ()
 toNix args@Args{..} remoteUri baseDir StackConfig{..} =

--- a/src/Stack2nix.hs
+++ b/src/Stack2nix.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 
+{-# OPTIONS_GHC -Wall -Wno-type-defaults #-}
+
 module Stack2nix
   ( Args(..)
   , Package(..)
@@ -51,13 +53,9 @@ import           System.IO                    (hPutStrLn, stderr, stdout)
 import           System.IO.Temp               (withSystemTempDirectory)
 import           Text.ParserCombinators.ReadP (readP_to_S)
 
-data Args = Args
-  { argRev     :: Maybe String
-  , argOutFile :: Maybe FilePath
-  , argUri     :: String
-  }
-  deriving (Show)
+import           Stack2nix.Types
 
+
 data StackConfig = StackConfig
   { resolver  :: Text
   , packages  :: [Package]
@@ -101,15 +99,15 @@ instance FromJSON RemotePkgConf where
 parseStackYaml :: BS.ByteString -> Maybe StackConfig
 parseStackYaml = Y.decode
 
-checkRuntimeDeps :: IO ()
-checkRuntimeDeps = do
+checkRuntimeDeps :: Args -> IO ()
+checkRuntimeDeps args = do
   checkVer "cabal2nix" "2.2.1"
   checkVer "git" "2"
   checkVer "cabal" "1"
   where
     checkVer prog minVer = do
       hPutStrLn stderr $ unwords ["Ensuring", prog, "version is >=", minVer, "..."]
-      (result, stdout, stderr) <- runCmd prog ["--version"] `onException` (error $ "Failed to run " ++ prog ++ ". Not found in PATH.")
+      (result, stdout, stderr) <- runCmd args prog ["--version"] `onException` (error $ "Failed to run " ++ prog ++ ". Not found in PATH.")
       if result
       then let
              -- heuristic for parsing version from stdout
@@ -125,7 +123,7 @@ checkRuntimeDeps = do
 
 stack2nix :: Args -> IO ()
 stack2nix args@Args{..} = do
-  checkRuntimeDeps
+  checkRuntimeDeps args
   updateCabalPackageIndex
   isLocalRepo <- doesFileExist $ argUri </> "stack.yaml"
   if isLocalRepo
@@ -135,20 +133,20 @@ stack2nix args@Args{..} = do
   where
     updateCabalPackageIndex :: IO ()
     updateCabalPackageIndex =
-      getEnv "HOME" >>= \home -> runCmdFrom home "cabal" ["update"] >> return ()
+      getEnv "HOME" >>= \home -> runCmdFrom args home "cabal" ["update"] >> return ()
 
     tryGit :: FilePath -> IO ()
     tryGit tmpDir = do
-      git $ OutsideRepo $ Clone argUri tmpDir
+      git args $ OutsideRepo $ Clone argUri tmpDir
       case argRev of
-        Just r  -> git $ InsideRepo tmpDir $ Checkout r
+        Just r  -> git args $ InsideRepo tmpDir $ Checkout r
         Nothing -> return mempty
 
     handleStackConfig :: Maybe String -> FilePath -> IO ()
     handleStackConfig remoteUri localDir = do
       let fname = localDir </> "stack.yaml"
       alreadyExists <- doesFileExist fname
-      unless alreadyExists $ runCmdFrom localDir "stack" ["init", "--system-ghc"]
+      unless alreadyExists $ runCmdFrom args localDir "stack" ["init", "--system-ghc"]
                              >> return ()
       contents <- BS.readFile fname
       case parseStackYaml contents of
@@ -156,21 +154,21 @@ stack2nix args@Args{..} = do
         Nothing     -> error $ "Failed to parse " <> (localDir </> "stack.yaml")
 
 -- Credit: https://stackoverflow.com/a/18898822/204305
-mapPool :: T.Traversable t => Int -> (a -> IO b) -> t a -> IO (t b)
-mapPool max' f xs = do
+mapPool :: T.Traversable t => Args -> (a -> IO b) -> t a -> IO (t b)
+mapPool Args{..} f xs = do
+  let max' = if argSerialise
+             then 1
+             else 4
   sem <- new max'
   mapConcurrently (with sem . f) xs
 
-c2nPoolSize :: Int
-c2nPoolSize = 4
-
 toNix :: Args -> Maybe String -> FilePath -> StackConfig -> IO ()
-toNix Args{..} remoteUri baseDir StackConfig{..} =
+toNix args@Args{..} remoteUri baseDir StackConfig{..} =
   withSystemTempDirectory "s2n" $ \outDir -> do
-    _ <- mapPool c2nPoolSize (genNixFile outDir) packages
-    overrides <- mapPool c2nPoolSize overrideFor =<< updateDeps outDir
-    _ <- mapPool c2nPoolSize (genNixFile outDir) packages
-    _ <- mapPool c2nPoolSize patchNixFile =<< glob (outDir </> "*.nix")
+    _ <- mapPool args (genNixFile outDir) packages
+    overrides <- mapPool args overrideFor =<< updateDeps outDir
+    _ <- mapPool args (genNixFile outDir) packages
+    _ <- mapPool args patchNixFile =<< glob (outDir </> "*.nix")
     writeFile (outDir </> "initialPackages.nix") $ initialPackages $ sort overrides
     pullInNixFiles $ outDir </> "initialPackages.nix"
     nf <- parseNixFile $ outDir </> "initialPackages.nix"
@@ -184,13 +182,13 @@ toNix Args{..} remoteUri baseDir StackConfig{..} =
         updateDeps :: FilePath -> IO [FilePath]
         updateDeps outDir = do
           hPutStrLn stderr $ "Updating deps from " ++ baseDir
-          (result, stdout, stderr') <- runCmdFrom baseDir "stack" ["list-dependencies", "--system-ghc", "--separator", "-"]
+          (result, stdout, stderr') <- runCmdFrom args baseDir "stack" ["list-dependencies", "--system-ghc", "--separator", "-"]
           if result
           then do
             let pkgs' = ["hscolour", "jailbreak-cabal", "cabal-doctest", "happy", "stringbuilder"] ++ lines stdout
             hPutStrLn stderr "Haskell dependencies:"
             mapM_ (hPutStrLn stderr) pkgs'
-            _ <- mapPool c2nPoolSize (\d -> catch (handleExtraDep outDir d) ignoreError) $ pack <$> pkgs'
+            _ <- mapPool args (\d -> catch (handleExtraDep outDir d) ignoreError) $ pack <$> pkgs'
             return ()
           else error $ unlines ["FAILED: stack list-dependencies", stderr']
           glob (outDir </> "*.nix")
@@ -201,9 +199,9 @@ toNix Args{..} remoteUri baseDir StackConfig{..} =
 
         genNixFile :: FilePath -> Package -> IO ()
         genNixFile outDir (LocalPkg relPath) =
-          cabal2nix (fromMaybe baseDir remoteUri) (pack <$> argRev) (Just relPath) (Just outDir)
+          cabal2nix args (fromMaybe baseDir remoteUri) (pack <$> argRev) (Just relPath) (Just outDir)
         genNixFile outDir (RemotePkg RemotePkgConf{..}) =
-          cabal2nix (unpack gitUrl) (Just commit) Nothing (Just outDir)
+          cabal2nix args (unpack gitUrl) (Just commit) Nothing (Just outDir)
 
         patchNixFile :: FilePath -> IO ()
         patchNixFile fname = do
@@ -239,7 +237,7 @@ toNix Args{..} remoteUri baseDir StackConfig{..} =
 
         handleExtraDep :: FilePath -> Text -> IO ()
         handleExtraDep outDir dep =
-          cabal2nix ("cabal://" <> unpack dep) Nothing Nothing (Just outDir)
+          cabal2nix args ("cabal://" <> unpack dep) Nothing Nothing (Just outDir)
 
         overrideFor :: FilePath -> IO String
         overrideFor nixFile = do
@@ -326,9 +324,9 @@ toNix Args{..} remoteUri baseDir StackConfig{..} =
 
         dropParams :: NExpr -> [Text] -> NExpr
         dropParams (Fix (NAbs (ParamSet (FixedParamSet paramMap) x)
-                    (Fix (NApp mkDeriv (Fix (NSet args)))))) names =
+                    (Fix (NApp mkDeriv (Fix (NSet args')))))) names =
           Fix (NAbs (ParamSet (FixedParamSet $ foldr Map.delete paramMap names) x)
-                    (Fix (NApp mkDeriv (Fix (NSet args)))))
+                    (Fix (NApp mkDeriv (Fix (NSet args')))))
         dropParams x _ = x
 
         initialPackages overrides = unlines $
@@ -340,7 +338,7 @@ toNix Args{..} remoteUri baseDir StackConfig{..} =
           ]
 
         defaultNix pkgsNixExpr = unlines
-          [ "# Generated using stack2nix " ++ display version ++ "."
+          [ "# Generated using stack2nix " ++ "" ++ "."
           , "#"
           , "# Only works with sufficiently recent nixpkgs, e.g. \"NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/21a8239452adae3a4717772f4e490575586b2755.tar.gz\"."
           , ""

--- a/src/Stack2nix/External/Cabal2nix.hs
+++ b/src/Stack2nix/External/Cabal2nix.hs
@@ -12,14 +12,13 @@ import           System.FilePath         ((</>))
 -- Requires cabal2nix >= 2.2 in PATH
 cabal2nix :: FilePath -> Maybe Text -> Maybe FilePath -> Maybe FilePath -> IO ()
 cabal2nix uri commit subpath odir = do
-  result <- runCmd exe (args $ fromMaybe "." subpath)
-  case result of
-    Right stdout ->
-      let basename = pname stdout <> ".nix"
-          fname = maybe basename (</> basename) odir
-      in
-      writeFile fname stdout
-    Left stderr  -> error stderr
+  (result, stdout, stderr) <- runCmd exe (args $ fromMaybe "." subpath)
+  if result
+  then do
+         let basename = pname stdout <> ".nix"
+             fname    = maybe basename (</> basename) odir
+         writeFile fname stdout
+  else error stderr
   where
     exe = "cabal2nix"
 

--- a/src/Stack2nix/External/Cabal2nix.hs
+++ b/src/Stack2nix/External/Cabal2nix.hs
@@ -7,13 +7,14 @@ import           Data.Maybe              (fromMaybe)
 import           Data.Monoid             ((<>))
 import           Data.Text               (Text, unpack)
 import           Stack2nix.External.Util (runCmd)
+import           Stack2nix.Types
 import           System.FilePath         ((</>))
 import qualified System.IO               as Sys
 
 -- Requires cabal2nix >= 2.2 in PATH
-cabal2nix :: FilePath -> Maybe Text -> Maybe FilePath -> Maybe FilePath -> IO ()
-cabal2nix uri commit subpath odir = do
-  (result, stdout, stderr) <- runCmd exe (args $ fromMaybe "." subpath)
+cabal2nix :: Args -> FilePath -> Maybe Text -> Maybe FilePath -> Maybe FilePath -> IO ()
+cabal2nix argz uri commit subpath odir = do
+  (result, stdout, stderr) <- runCmd argz exe (args $ fromMaybe "." subpath)
   if result
   then do
          let basename = pname stdout <> ".nix"

--- a/src/Stack2nix/External/Cabal2nix.hs
+++ b/src/Stack2nix/External/Cabal2nix.hs
@@ -8,6 +8,7 @@ import           Data.Monoid             ((<>))
 import           Data.Text               (Text, unpack)
 import           Stack2nix.External.Util (runCmd)
 import           System.FilePath         ((</>))
+import qualified System.IO               as Sys
 
 -- Requires cabal2nix >= 2.2 in PATH
 cabal2nix :: FilePath -> Maybe Text -> Maybe FilePath -> Maybe FilePath -> IO ()
@@ -17,6 +18,7 @@ cabal2nix uri commit subpath odir = do
   then do
          let basename = pname stdout <> ".nix"
              fname    = maybe basename (</> basename) odir
+         Sys.hPutStrLn Sys.stderr stderr
          writeFile fname stdout
   else error stderr
   where

--- a/src/Stack2nix/External/Cabal2nix.hs
+++ b/src/Stack2nix/External/Cabal2nix.hs
@@ -2,6 +2,7 @@ module Stack2nix.External.Cabal2nix (
   cabal2nix
   ) where
 
+import           Control.Monad
 import           Data.List               (stripPrefix, takeWhile)
 import           Data.Maybe              (fromMaybe)
 import           Data.Monoid             ((<>))
@@ -19,7 +20,8 @@ cabal2nix argz uri commit subpath odir = do
   then do
          let basename = pname stdout <> ".nix"
              fname    = maybe basename (</> basename) odir
-         Sys.hPutStrLn Sys.stderr stderr
+         unless (null stderr) $
+           Sys.hPutStrLn Sys.stderr stderr
          writeFile fname stdout
   else error stderr
   where

--- a/src/Stack2nix/External/Util.hs
+++ b/src/Stack2nix/External/Util.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE RecordWildCards   #-}
+
 module Stack2nix.External.Util where
 
+import           Control.Monad
 import           Data.List
 import           Data.Monoid
 import           System.Directory (getCurrentDirectory)
@@ -7,22 +10,30 @@ import           System.Exit      (ExitCode (..))
 import           System.Process   (CreateProcess (..))
 import           System.Process   (proc, readCreateProcessWithExitCode)
 import qualified System.IO               as Sys
+import           Text.Printf      (printf)
 
+import           Stack2nix.Types
+
+
 type CmdResult = (Bool, String, String)
 
-runCmdFrom :: FilePath -> String -> [String] -> IO CmdResult
-runCmdFrom dir prog args = do
-  Sys.hPutStrLn Sys.stderr $ "runCmdFrom '" <> dir <> "' '" <> prog <> " " <> show (intercalate " " args)
+
+runCmdFrom :: Args -> FilePath -> String -> [String] -> IO CmdResult
+runCmdFrom Args{..} dir prog args = do
+  when argVerbose $
+    Sys.hPutStrLn Sys.stderr $ "runCmdFrom \"" <> dir <> "\" " <> prog <> " " <> show (intercalate " " args)
   (exitCode, stdout, stderr) <- readCreateProcessWithExitCode (fromDir dir (proc prog args)) ""
   case exitCode of
     ExitSuccess -> return $ (True,  stdout, stderr)
-    _           -> return $ (False, stdout, stderr)
+    _           -> return $ if argErrorsFatal
+                            then error $ printf "FATAL: command %s %s returned exitCore=%s" prog (intercalate " " args) (show exitCode)
+                            else (False, stdout, stderr)
   where
     fromDir :: FilePath -> CreateProcess -> CreateProcess
     fromDir d procDesc = procDesc { cwd = Just d }
 
-runCmd :: String -> [String] -> IO CmdResult
-runCmd prog args = getCurrentDirectory >>= (\d -> runCmdFrom d prog args)
+runCmd :: Args -> String -> [String] -> IO CmdResult
+runCmd args prog progargs = getCurrentDirectory >>= (\d -> runCmdFrom args d prog progargs)
 
 failHard :: CmdResult -> IO ()
 failHard (False, _, stderr) = error $ show stderr

--- a/src/Stack2nix/External/Util.hs
+++ b/src/Stack2nix/External/Util.hs
@@ -1,14 +1,18 @@
 module Stack2nix.External.Util where
 
+import           Data.List
+import           Data.Monoid
 import           System.Directory (getCurrentDirectory)
 import           System.Exit      (ExitCode (..))
 import           System.Process   (CreateProcess (..))
 import           System.Process   (proc, readCreateProcessWithExitCode)
+import qualified System.IO               as Sys
 
 type CmdResult = (Bool, String, String)
 
 runCmdFrom :: FilePath -> String -> [String] -> IO CmdResult
 runCmdFrom dir prog args = do
+  Sys.hPutStrLn Sys.stderr $ "runCmdFrom '" <> dir <> "' '" <> prog <> " " <> show (intercalate " " args)
   (exitCode, stdout, stderr) <- readCreateProcessWithExitCode (fromDir dir (proc prog args)) ""
   case exitCode of
     ExitSuccess -> return $ (True,  stdout, stderr)

--- a/src/Stack2nix/External/Util.hs
+++ b/src/Stack2nix/External/Util.hs
@@ -1,27 +1,25 @@
 module Stack2nix.External.Util where
 
-import           Data.List        (intercalate)
-import           Data.Monoid      ((<>))
 import           System.Directory (getCurrentDirectory)
 import           System.Exit      (ExitCode (..))
 import           System.Process   (CreateProcess (..))
 import           System.Process   (proc, readCreateProcessWithExitCode)
 
-runCmdFrom :: FilePath -> String -> [String] -> IO (Either String String)
+type CmdResult = (Bool, String, String)
+
+runCmdFrom :: FilePath -> String -> [String] -> IO CmdResult
 runCmdFrom dir prog args = do
   (exitCode, stdout, stderr) <- readCreateProcessWithExitCode (fromDir dir (proc prog args)) ""
   case exitCode of
-    ExitSuccess -> return $ Right stdout
-    _           -> return $ Left $ "Command failed: " ++ cmd ++ "\n" ++ stderr
+    ExitSuccess -> return $ (True,  stdout, stderr)
+    _           -> return $ (False, stdout, stderr)
   where
     fromDir :: FilePath -> CreateProcess -> CreateProcess
     fromDir d procDesc = procDesc { cwd = Just d }
 
-    cmd = "cd \"" <> dir <> "\" && " <> intercalate " " (prog:args)
-
-runCmd :: String -> [String] -> IO (Either String String)
+runCmd :: String -> [String] -> IO CmdResult
 runCmd prog args = getCurrentDirectory >>= (\d -> runCmdFrom d prog args)
 
-failHard :: Show a => Either a b -> IO ()
-failHard (Left stderr) = error $ show stderr
-failHard (Right _)     = mempty
+failHard :: CmdResult -> IO ()
+failHard (False, _, stderr) = error $ show stderr
+failHard (True, _, _)       = mempty

--- a/src/Stack2nix/External/VCS/Git.hs
+++ b/src/Stack2nix/External/VCS/Git.hs
@@ -4,6 +4,7 @@ module Stack2nix.External.VCS.Git
   ) where
 
 import           Stack2nix.External.Util (failHard, runCmd, runCmdFrom)
+import           Stack2nix.Types
 
 data Command = OutsideRepo ExternalCmd
              | InsideRepo FilePath InternalCmd
@@ -16,14 +17,14 @@ exe :: String
 exe = "git"
 
 -- Requires git binary in PATH
-git :: Command -> IO ()
-git (OutsideRepo cmd)    = runExternal cmd
-git (InsideRepo dir cmd) = runInternal dir cmd
+git :: Args -> Command -> IO ()
+git args (OutsideRepo cmd)    = runExternal args  cmd
+git args (InsideRepo dir cmd) = runInternal args dir cmd
 
-runExternal :: ExternalCmd -> IO ()
-runExternal (Clone uri dir) = do
-   runCmd exe ["clone", uri, dir] >>= failHard
+runExternal :: Args -> ExternalCmd -> IO ()
+runExternal args (Clone uri dir) = do
+   runCmd args exe ["clone", uri, dir] >>= failHard
 
-runInternal :: FilePath -> InternalCmd -> IO ()
-runInternal repoDir (Checkout ref) = do
-   runCmdFrom repoDir exe ["checkout", ref] >>= failHard
+runInternal :: Args -> FilePath -> InternalCmd -> IO ()
+runInternal args repoDir (Checkout ref) = do
+   runCmdFrom args repoDir exe ["checkout", ref] >>= failHard

--- a/src/Stack2nix/Types.hs
+++ b/src/Stack2nix/Types.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+module Stack2nix.Types where
+
+data Args = Args
+  { argRev         :: Maybe String
+  , argOutFile     :: Maybe FilePath
+  , argUri         :: String
+  , argErrorsFatal :: Bool
+  , argSerialise   :: Bool
+  , argVerbose     :: Bool
+  }
+  deriving (Show)

--- a/stack2nix.cabal
+++ b/stack2nix.cabal
@@ -39,6 +39,7 @@ library
                      , Stack2nix.External.VCS
                      , Stack2nix.External.VCS.Git
                      , Stack2nix.External.Util
+                     , Stack2nix.Types
                      , Paths_stack2nix
   ghc-options:         -Wall
   default-language:    Haskell2010

--- a/stack2nix/Main.hs
+++ b/stack2nix/Main.hs
@@ -1,6 +1,7 @@
 module Main ( main ) where
 
 import           Data.Semigroup      ((<>))
+import           Data.Maybe
 import           Distribution.Text   (display)
 import           Options.Applicative
 import           Stack2nix
@@ -10,13 +11,16 @@ args = Args
        <$> optional (strOption $ long "revision" <> help "revision to use when fetching from VCS")
        <*> optional (strOption $ short 'o' <> help "output file for generated nix expression")
        <*> strArgument (metavar "URI")
+       <*> (fromMaybe False <$> (optional (switch $ long "errors-fatal" <> short 'f' <> help "Force global failure from non-zero subprocess return status")))
+       <*> (fromMaybe False <$> (optional (switch $ long "serialise"    <> short 's' <> help "Disable parallelism")))
+       <*> (fromMaybe False <$> (optional (switch $ long "verbose"      <> short 'v' <> help "Verbose output")))
 
 main :: IO ()
 main = stack2nix =<< execParser opts
   where
     opts = info
       (helper
-       <*> infoOption ("stack2nix " ++ display version) (long "version" <> help "Show version number")
+       <*> infoOption ("stack2nix ") (long "version" <> help "Show version number")
        <*> args) $
       fullDesc
       <> progDesc "Generate a nix expression for a Haskell package using stack"


### PR DESCRIPTION
This does:

1. change `runCmd` return value to carry complete information -- `status`, `stdout` and `stderr`
2. adapt the callers
3. make `cabal2nix` print its `stderr` regardless of success