### PR TITLE
Enable doCheck on a package using --test option.

### DIFF
--- a/stack2nix/Main.hs
+++ b/stack2nix/Main.hs
@@ -10,7 +10,7 @@ args = Args
        <$> optional (strOption $ long "revision" <> help "revision to use when fetching from VCS")
        <*> optional (strOption $ short 'o' <> help "output file for generated nix expression" <> metavar "PATH")
        <*> option auto (short 'j' <> help "number of threads for subprocesses" <> showDefault <> value 1 <> metavar "INT")
-       <*> optional (strOption $ long "test" <> help "package to test" <> metavar "PKG")
+       <*> switch (long "test" <> help "enable tests")
        <*> strArgument (metavar "URI")
 
 main :: IO ()

--- a/stack2nix/Main.hs
+++ b/stack2nix/Main.hs
@@ -10,6 +10,7 @@ args = Args
        <$> optional (strOption $ long "revision" <> help "revision to use when fetching from VCS")
        <*> optional (strOption $ short 'o' <> help "output file for generated nix expression" <> metavar "PATH")
        <*> option auto (short 'j' <> help "number of threads for subprocesses" <> showDefault <> value 1 <> metavar "INT")
+       <*> optional (strOption $ long "test" <> help "package to test" <> metavar "PKG")
        <*> strArgument (metavar "URI")
 
 main :: IO ()


### PR DESCRIPTION
By default the mkDerivations all have the `check` phase disabled; however, it's sometimes useful to enable it for the target package.