### PR TITLE
Replace our StackConfig with stacks BuildConfig

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -2,6 +2,8 @@
 #! nix-shell -p cabal2nix stack nix-prefetch-git git cabal-install ghc -i bash
 #! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/f4312a30241fd88c3b4bb38ba62999865073ad94.tar.gz
 
+export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/f4312a30241fd88c3b4bb38ba62999865073ad94.tar.gz
+
 set -ex
 
 # set up local environment
@@ -12,7 +14,7 @@ cabal2nix --version
 
 # build and install
 stack --nix --system-ghc setup
-stack --nix --system-ghc install
+stack --nix --system-ghc install --fast
 
 # smoke tests
 stack2nix -j4 -o /tmp/haskell-dummy-project1.nix \

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -p stack nix-prefetch-git git cabal-install ghc -i bash
+#! nix-shell -p cabal2nix stack nix-prefetch-git git cabal-install ghc -i bash
 #! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/f4312a30241fd88c3b4bb38ba62999865073ad94.tar.gz
 
 set -ex
@@ -8,7 +8,7 @@ set -ex
 PATH="$HOME/.local/bin:$PATH"
 
 # install cabal2nix 2.2.1
-stack --nix --system-ghc install cabal2nix-2.2.1
+cabal2nix --version
 
 # build and install
 stack --nix --system-ghc setup

--- a/src/Stack2nix.hs
+++ b/src/Stack2nix.hs
@@ -42,7 +42,7 @@ import           Stack2nix.External           (cabal2nix)
 import           Stack2nix.External.Util      (runCmd, runCmdFrom)
 import           Stack2nix.External.VCS.Git   (Command (..), ExternalCmd (..),
                                                InternalCmd (..), git)
-import           System.Directory             (doesFileExist)
+import           System.Directory             (doesFileExist, canonicalizePath)
 import           System.Environment           (getEnv)
 import           System.Exit                  (ExitCode (..))
 import           System.FilePath              (dropExtension, isAbsolute,
@@ -115,7 +115,8 @@ stack2nix args@Args{..} = do
       let stackFile = localDir </> "stack.yaml"
       alreadyExists <- doesFileExist stackFile
       unless alreadyExists $ void $ runCmdFrom localDir "stack" ["init", "--system-ghc"]
-      fp <- parseAbsFile stackFile
+      cp <- canonicalizePath stackFile
+      fp <- parseAbsFile cp
       lc <- withRunner LevelError True False ColorAuto False $ \runner -> do
         -- https://www.fpcomplete.com/blog/2017/07/the-rio-monad
         runRIO runner $ loadConfig mempty Nothing (SYLOverride fp)

--- a/src/Stack2nix/External/Cabal2nix.hs
+++ b/src/Stack2nix/External/Cabal2nix.hs
@@ -12,12 +12,12 @@ import           System.FilePath         ((</>))
 
 -- Requires cabal2nix >= 2.2 in PATH
 cabal2nix :: FilePath -> Maybe Text -> Maybe FilePath -> Maybe FilePath -> IO (ExitCode, String, String)
-cabal2nix uri commit subpath odir = do
+cabal2nix uri commit subpath outDir = do
   result <- runCmd exe (args $ fromMaybe "." subpath)
   case result of
     (ExitSuccess, stdout, _) ->
       let basename = pname stdout <> ".nix"
-          fname = maybe basename (</> basename) odir
+          fname = maybe basename (</> basename) outDir
       in
       writeFile fname stdout >> return result
     _ -> return result

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,12 @@
-resolver: lts-8.15
+resolver: lts-9.0
 
 packages:
 - '.'
+- location:
+   git: https://github.com/commercialhaskell/stack.git
+   commit: 6eda315554dc780196275df9dec90a9fe57b8cf7
+  extra-dep: true
+
 
 extra-deps:
 - hnix-0.3.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,4 +13,7 @@ extra-deps:
 
 flags: {}
 
+nix:
+  packages: [zlib,gmp]
+
 extra-package-dbs: []

--- a/stack2nix.cabal
+++ b/stack2nix.cabal
@@ -25,11 +25,13 @@ library
                      , data-fix == 0.0.4
                      , directory >= 1.3 && < 1.4
                      , filepath >= 1.4.1.1 && < 1.5
-                     , Glob >= 0.7.14 && < 0.8
+                     , Glob >= 0.7.14 && < 0.9
                      , hnix >= 0.3.4 && < 0.4
                      , monad-parallel >= 0.7.2.2 && < 0.8
                      , process >= 1.4.3 && < 1.5
                      , SafeSemaphore >= 0.10.1 && < 0.11
+                     , stack >= 0.5.1
+                     , path
                      , temporary >= 1.2.0.4 && < 1.3
                      , text >= 1.2.2.1 && < 1.3
                      , yaml >= 0.8.22.1 && < 0.9


### PR DESCRIPTION
Change our own type for parsing `stack.yaml` with `Stack.Config.BuildConfig` to make sure it's always parsed correctly.

This uses `stack` master since types have changed significantly. 

`./script/travis.sh` passes, I still have to test on a bigger project.

Thanks to @jmitchell and @k0001 for help!

PS: I next plan to remove the rest of subprocess calls to stack.