### PR TITLE
Default to 4 threads since most of our work is IO bound

### DIFF
--- a/stack2nix/Main.hs
+++ b/stack2nix/Main.hs
@@ -9,7 +9,7 @@ args :: Parser Args
 args = Args
        <$> optional (strOption $ long "revision" <> help "revision to use when fetching from VCS")
        <*> optional (strOption $ short 'o' <> help "output file for generated nix expression" <> metavar "PATH")
-       <*> option auto (short 'j' <> help "number of threads for subprocesses" <> showDefault <> value 1 <> metavar "INT")
+       <*> option auto (short 'j' <> help "number of threads for subprocesses" <> showDefault <> value 4 <> metavar "INT")
        <*> switch (long "test" <> help "enable tests")
        <*> switch (long "haddock" <> help "enable documentation generation")
        <*> strArgument (metavar "URI")


### PR DESCRIPTION
With the release of Nix 1.11.12 we don't have concurrent
builtins.fetchTarball problem anymore, so for now let's
assume a reasonable default is 4 threads and see how it
plays out.

