### PR TITLE
Support nix caching for local subpath depedencies

### DIFF
--- a/src/Stack2nix.hs
+++ b/src/Stack2nix.hs
@@ -170,7 +170,7 @@ toNix Args{..} remoteUri baseDir BuildConfig{..} =
         genNixFile :: (FilePath, PackageLocationIndex Subdirs) -> IO ((FilePath, PackageLocationIndex Subdirs), (ExitCode, String, String))
         genNixFile (_, pli@(PLIndex _)) = return (("", pli), (ExitSuccess, "", ""))
         genNixFile input@(outDir, PLOther (PLFilePath relPath)) = do
-          r <- cabal2nix (fromMaybe baseDir remoteUri) (pack <$> argRev) (Just relPath) (Just outDir)
+          r <- cabal2nix (fromMaybe (baseDir </> relPath) remoteUri) (pack <$> argRev) (const relPath <$> remoteUri) (Just outDir)
           return (input, r)
         genNixFile input@(outDir, PLOther (PLRepo repo)) = do
           case repoSubdirs repo of


### PR DESCRIPTION
When a local target project has dependencies in sub-directories, have cabal2nix generate a cache-friendly nix expression. In particular, this avoids manipulating `srcRoot` during `postUnpack` phase when possible.

Sanity check:

```
$ git clone https://github.com/jmitchell/haskell-multi-package-demo1
$ cd haskell-multi-package-demo1
$ stack2nix . > default.nix
$ NIX_PATH="nixpkgs=https://github.com/NixOS/nixpkgs/archive/f4312a30241fd88c3b4bb38ba62999865073ad94.tar.gz" nix-build -A haskell-multi-proj-demo1
```

Also verified targeting remote repos with subpath dependencies still works:

```
$ stack2nix -j8 https://github.com/jmitchell/haskell-multi-package-demo1.git > default.nix
$ NIX_PATH="nixpkgs=https://github.com/NixOS/nixpkgs/archive/f4312a30241fd88c3b4bb38ba62999865073ad94.tar.gz" nix-build -A haskell-multi-proj-demo1
```