### PR TITLE
stack2nix.nix: support macOS

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,4 +2,16 @@
 
 with (import <nixpkgs/pkgs/development/haskell-modules/lib.nix> { inherit pkgs; } ); 
 
-justStaticExecutables (import ./stack2nix.nix { inherit pkgs; }).stack2nix
+((import ./stack2nix.nix { inherit pkgs; }).override {
+  overrides = self: super: {
+    stack2nix = justStaticExecutables super.stack2nix;
+
+    # https://github.com/NixOS/cabal2nix/issues/146
+    hinotify = if pkgs.stdenv.isDarwin then self.hfsevents else super.hinotify;
+    # Darwin fixes upstreamed in nixpkgs commit 71bebd52547f4486816fd320bb3dc6314f139e67
+    hfsevents = self.callPackage ./hfsevents.nix { inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa CoreServices; };
+    fsnotify = if pkgs.stdenv.isDarwin
+      then addBuildDepend (dontCheck super.fsnotify) pkgs.darwin.apple_sdk.frameworks.Cocoa
+      else dontCheck super.fsnotify;
+  };
+}).stack2nix

--- a/hfsevents.nix
+++ b/hfsevents.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, bytestring, cereal, Cocoa, CoreServices
+, fetchgit, mtl, stdenv, text
+}:
+mkDerivation {
+  pname = "hfsevents";
+  version = "0.1.6";
+  src = fetchgit {
+    url = "https://github.com/luite/hfsevents.git";
+    sha256 = "0smpq3yd5m9jd9fpanaqvhadv6qcyp9y5bz0dya0rnxqg909m973";
+    rev = "25a53d417d7c7a8fc3116b63e3ba14ca7c8f188f";
+  };
+  libraryHaskellDepends = [ base bytestring cereal mtl text ];
+  librarySystemDepends = [ Cocoa ];
+  libraryToolDepends = [ CoreServices ];
+  homepage = "http://github.com/luite/hfsevents";
+  description = "File/folder watching for OS X";
+  license = stdenv.lib.licenses.bsd3;
+  platforms = [ "x86_64-darwin" ];
+}


### PR DESCRIPTION
There might be macOS developer(s) wanting to build stack2nix on macOS, this fixes https://github.com/NixOS/cabal2nix/issues/146 in overriding manner.