### PR TITLE
Hardcode platform to linux

### DIFF
--- a/src/Stack2nix/External/Cabal2nix.hs
+++ b/src/Stack2nix/External/Cabal2nix.hs
@@ -28,6 +28,7 @@ cabal2nix uri commit subpath outDir = do
     args dir = concat
       [ maybe [] (\c -> ["--revision", unpack c]) commit
       , ["--subpath", dir]
+      , ["--system", "x86_64-linux"]
       , ["--no-check", "--no-haddock"]
       , [uri]
       ]


### PR DESCRIPTION
For now let's assume linux, otherwise the default is system default, which is non-deterministic.

For future improvements see #55