### PR TITLE
Add --platform cli flag 

### DIFF
--- a/src/Stack2nix/External/Stack.hs
+++ b/src/Stack2nix/External/Stack.hs
@@ -7,12 +7,13 @@ module Stack2nix.External.Stack
 
 import           Control.Applicative           ((<|>))
 import           Control.Monad                 (unless)
+import           Control.Monad.Reader          (local)
 import           Data.List                     (isInfixOf, nubBy, sortBy)
 import qualified Data.Map.Strict               as M
 import           Data.Maybe                    (fromJust)
 import qualified Data.Set                      as S
 import           Data.Text                     (pack, unpack)
-import           Data.Time                     (UTCTime)
+import           Lens.Micro                    (set)
 import           Options.Applicative
 import           Stack.Build                   (mkBaseConfigOpts,
                                                 withLoadPackage)
@@ -121,39 +122,38 @@ planAndGenerate :: HasEnvConfig env
                 -> FilePath
                 -> Maybe String
                 -> [PackageRef]
-                -> Maybe String
-                -> Maybe UTCTime
-                -> Int
+                -> Args
                 -> IO ()
                 -> RIO env ()
-planAndGenerate boptsCli baseDir outDir remoteUri revPkgs argRev hSnapshot threads doAfter = do
-  bopts <- view buildOptsL
-  let profiling = boptsLibProfile bopts || boptsExeProfile bopts
-  let symbols = not (boptsLibStrip bopts || boptsExeStrip bopts)
-  menv <- getMinimalEnvOverride
+planAndGenerate boptsCli baseDir outDir remoteUri revPkgs Args{..} doAfter = do
+  local (set platformL argPlatform) $ do
+    bopts <- view buildOptsL
+    let profiling = boptsLibProfile bopts || boptsExeProfile bopts
+    let symbols = not (boptsLibStrip bopts || boptsExeStrip bopts)
+    menv <- getMinimalEnvOverride
 
-  (_targets, mbp, locals, extraToBuild, sourceMap) <- loadSourceMapFull NeedTargets boptsCli
-  _stackYaml <- view stackYamlL
+    (_targets, mbp, locals, extraToBuild, sourceMap) <- loadSourceMapFull NeedTargets boptsCli
+    _stackYaml <- view stackYamlL
 
-  (installedMap, _globalDumpPkgs, _snapshotDumpPkgs, localDumpPkgs) <-
-    getInstalled menv
-                 GetInstalledOpts
-                   { getInstalledProfiling = profiling
-                   , getInstalledHaddock   = shouldHaddockDeps bopts
-                   , getInstalledSymbols   = symbols }
-                 sourceMap
+    (installedMap, _globalDumpPkgs, _snapshotDumpPkgs, localDumpPkgs) <-
+      getInstalled menv
+                   GetInstalledOpts
+                     { getInstalledProfiling = profiling
+                     , getInstalledHaddock   = shouldHaddockDeps bopts
+                     , getInstalledSymbols   = symbols }
+                   sourceMap
 
-  baseConfigOpts <- mkBaseConfigOpts boptsCli
-  plan <- withLoadPackage $ \loadPackage ->
-    constructPlan mbp baseConfigOpts locals extraToBuild localDumpPkgs loadPackage sourceMap installedMap (boptsCLIInitialBuildSteps boptsCli)
-  -- hscolour is needed until https://github.com/NixOS/nixpkgs/issues/32609 is addressed
-  hscolour <-parsePackageIdentifier "hscolour-1.24.4"
-  let pkgs = prioritize $ planToPackages plan ++ revPkgs ++ [CabalPackage hscolour]
-  liftIO $ hPutStrLn stderr $ "plan:\n" ++ show pkgs
+    baseConfigOpts <- mkBaseConfigOpts boptsCli
+    plan <- withLoadPackage $ \loadPackage ->
+      constructPlan mbp baseConfigOpts locals extraToBuild localDumpPkgs loadPackage sourceMap installedMap (boptsCLIInitialBuildSteps boptsCli)
+    -- hscolour is needed until https://github.com/NixOS/nixpkgs/issues/32609 is addressed
+    hscolour <-parsePackageIdentifier "hscolour-1.24.4"
+    let pkgs = prioritize $ planToPackages plan ++ revPkgs ++ [CabalPackage hscolour]
+    liftIO $ hPutStrLn stderr $ "plan:\n" ++ show pkgs
 
-  hackageDB <- liftIO $ loadHackageDB Nothing hSnapshot
-  void $ liftIO $ mapPool threads (genNixFile baseDir outDir remoteUri argRev hackageDB) pkgs
-  liftIO doAfter
+    hackageDB <- liftIO $ loadHackageDB Nothing argHackageSnapshot
+    void $ liftIO $ mapPool argThreads (genNixFile baseDir outDir remoteUri argRev hackageDB) pkgs
+    liftIO doAfter
 
 runPlan :: FilePath
         -> FilePath
@@ -173,7 +173,7 @@ runPlan baseDir outDir remoteUri revPkgs lc args@Args{..} doAfter = do
              pure $ globalOpts baseDir stackRoot includes libs args
   -- hPutStrLn stderr $ "stack global opts:\n" ++ ppShow globals
   -- hPutStrLn stderr $ "stack build opts:\n" ++ ppShow buildOpts
-  withBuildConfig globals $ planAndGenerate buildOpts baseDir outDir remoteUri revPkgs argRev argHackageSnapshot argThreads doAfter
+  withBuildConfig globals $ planAndGenerate buildOpts baseDir outDir remoteUri revPkgs args doAfter
 
 {-
   TODO:

--- a/src/Stack2nix/Types.hs
+++ b/src/Stack2nix/Types.hs
@@ -1,6 +1,7 @@
 module Stack2nix.Types where
 
 import Data.Time (UTCTime)
+import Distribution.System (Platform)
 
 data Args = Args
   { argRev             :: Maybe String
@@ -9,6 +10,7 @@ data Args = Args
   , argTest            :: Bool
   , argHaddock         :: Bool
   , argHackageSnapshot :: Maybe UTCTime
+  , argPlatform        :: Platform
   , argUri             :: String
   , argVerbose         :: Bool
   }

--- a/stack2nix.cabal
+++ b/stack2nix.cabal
@@ -28,6 +28,8 @@ library
                      , filepath >= 1.4.1.1 && < 1.5
                      , Glob >= 0.7.14 && < 0.9
                      , hnix >= 0.3.4 && < 0.4
+                     , mtl
+                     , microlens
                      , optparse-applicative >= 0.13.2 && < 0.14
                      , path
                      , process >= 1.4.3 && < 1.5

--- a/stack2nix.nix
+++ b/stack2nix.nix
@@ -3470,7 +3470,7 @@ self: {
           description = "The Haskell Tool Stack";
           license = stdenv.lib.licenses.bsd3;
         }) {};
-      stack2nix = callPackage ({ Cabal, Glob, SafeSemaphore, async, base, cabal2nix, containers, data-fix, directory, distribution-nixpkgs, filepath, hnix, mkDerivation, optparse-applicative, path, process, regex-pcre, stack, stdenv, temporary, text, time }:
+      stack2nix = callPackage ({ Cabal, Glob, SafeSemaphore, async, base, cabal2nix, containers, data-fix, directory, distribution-nixpkgs, filepath, hnix, microlens, mkDerivation, mtl, optparse-applicative, path, process, regex-pcre, stack, stdenv, temporary, text, time }:
       mkDerivation {
           pname = "stack2nix";
           version = "0.1.3.1";
@@ -3489,6 +3489,8 @@ self: {
             filepath
             Glob
             hnix
+            microlens
+            mtl
             optparse-applicative
             path
             process


### PR DESCRIPTION
Allow specifying platform instead of defaulting to current system.

This is one of the impurities that affect the generated package output.

Fixes #55 #56

I've verified changes by running them on cardano-sl and got the following difference between darwin and linux:

```
3903c3903
<       fsnotify = callPackage ({ async, base, containers, directory, filepath, hfsevents, mkDerivation, stdenv, text, time, unix-compat }:
---
>       fsnotify = callPackage ({ async, base, containers, directory, filepath, hinotify, mkDerivation, stdenv, text, time, unix-compat }:
3914c3914
<             hfsevents
---
>             hinotify
4120c4120
<       hfsevents = callPackage ({ Cocoa, CoreServices, base, bytestring, cereal, mkDerivation, mtl, stdenv, text, unix }:
---
>       hinotify = callPackage ({ async, base, containers, directory, mkDerivation, stdenv, unix }:
4122,4124c4122,4124
<           pname = "hfsevents";
<           version = "0.1.6";
<           sha256 = "74c3f3f3a5e55fff320c352a2d481069ff915860a0ab970864c6a0e6b65d3f05";
---
>           pname = "hinotify";
>           version = "0.3.9";
>           sha256 = "f2480e4c08a516831c2221eebc6a9d3242e892932d9315c34cbe92a101c5df99";
4125a4126
>             async
4127,4130c4128,4129
<             bytestring
<             cereal
<             mtl
<             text
---
>             containers
>             directory
4133,4138d4131
<           librarySystemDepends = [
<             Cocoa
<           ];
<           libraryToolDepends = [
<             CoreServices
<           ];
4141,4142c4134,4135
<           homepage = "http://github.com/luite/hfsevents";
<           description = "File/folder watching for OS X";
---
>           homepage = "https://github.com/kolmodin/hinotify.git";
>           description = "Haskell binding to inotify";
4144,4145c4137
<           platforms = [ "x86_64-darwin" ];
<         }) { Cocoa = pkgs.Cocoa; };
---
>         }) {};
```

cc @jmitchell 