### PR TITLE
Error out of stack.yaml doesn't exist

### DIFF
--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -12,4 +12,4 @@ STACK=$(nix-build -A stack $NIXPKGS)/bin
 NIX_PREFETCH=$(nix-build -A nix-prefetch-git $NIXPKGS)/bin
 GIT=$(nix-build -A git $NIXPKGS)/bin
 CABAL_INSTALL=$(nix-build -A cabal-install $NIXPKGS)/bin
-export PATH="$HOME/.local/bin:$STACK:$NIX_PREFETCH:$GIT:$CABAL_INSTALL:$PATH"
+export PATH="$STACK:$NIX_PREFETCH:$GIT:$CABAL_INSTALL:$HOME/.local/bin:$PATH"

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -11,13 +11,13 @@ source $scriptDir/init-env.sh
 # SMOKE TESTS
 
 # basic remote
-\time stack2nix -o /tmp/haskell-dummy-project1.nix \
+\time stack2nix --verbose -o /tmp/haskell-dummy-project1.nix \
 	  --revision 7e7d91d86ba0f86633ab37279c013879ade09e32 \
 	  https://github.com/jmitchell/haskell-dummy-project1.git
 \time nix-build -A haskell-dummy-package1 /tmp/haskell-dummy-project1.nix
 
 # multi remote
-\time stack2nix -o /tmp/haskell-multi-package-demo1.nix \
+\time stack2nix --verbose -o /tmp/haskell-multi-package-demo1.nix \
 	  --revision e3d9bd6d6066dab5222ce53fb7d234f28eafa2d5 \
 	  https://github.com/jmitchell/haskell-multi-package-demo1.git
 \time nix-build -A haskell-multi-proj-demo1 /tmp/haskell-multi-package-demo1.nix
@@ -28,6 +28,6 @@ git clone https://github.com/jmitchell/haskell-multi-package-demo1.git "$TMP_REP
 cd "$TMP_REPO"
 git checkout e3d9bd6d6066dab5222ce53fb7d234f28eafa2d5
 cd src
-\time stack2nix -o hmpd.nix ../
+\time stack2nix --verbose -o hmpd.nix ../
 \time nix-build -A haskell-multi-proj-demo1 hmpd.nix
 test $(grep "src = ../dep1" hmpd.nix | wc -l) -eq 1

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -12,7 +12,7 @@ source $scriptDir/init-env.sh
 
 # basic remote
 \time stack2nix --verbose -o /tmp/haskell-dummy-project1.nix \
-	  --revision 7e7d91d86ba0f86633ab37279c013879ade09e32 \
+	  --revision 31aac4dcc7b87d5cb62dafe9b9402346fdf449a6 \
 	  https://github.com/jmitchell/haskell-dummy-project1.git
 \time nix-build -A haskell-dummy-package1 /tmp/haskell-dummy-project1.nix
 

--- a/src/Stack2nix.hs
+++ b/src/Stack2nix.hs
@@ -87,7 +87,7 @@ stack2nix args@Args{..} = do
       logDebug args $ "handleStackConfig (remoteUri): " ++ show remoteUri
       let stackFile = localDir </> "stack.yaml"
       alreadyExists <- doesFileExist stackFile
-      unless alreadyExists $ void $ runCmdFrom localDir "stack" ["init", "--system-ghc"]
+      unless alreadyExists $ error $ stackFile <> " does not exist. Use 'stack init' to create it."
       logDebug args $ "handleStackConfig (alreadyExists): " ++ show alreadyExists
       cp <- canonicalizePath stackFile
       fp <- parseAbsFile cp


### PR DESCRIPTION
This means we'd have to add stack.yaml to https://github.com/jmitchell/haskell-multi-package-demo1.git

cc @jmitchell 