### PR TITLE
Add flag for stack yaml

### DIFF
--- a/src/Stack2nix.hs
+++ b/src/Stack2nix.hs
@@ -35,7 +35,7 @@ stack2nix args@Args{..} = do
   -- cwd <- getCurrentDirectory
   -- let projRoot = if isAbsolute argUri then argUri else cwd </> argUri
   let projRoot = argUri
-  isLocalRepo <- doesFileExist $ projRoot </> "stack.yaml"
+  isLocalRepo <- doesFileExist $ projRoot </> argStackYaml
   logDebug args $ "stack2nix (isLocalRepo): " ++ show isLocalRepo
   logDebug args $ "stack2nix (projRoot): " ++ show projRoot
   logDebug args $ "stack2nix (argUri): " ++ show argUri
@@ -61,7 +61,7 @@ stack2nix args@Args{..} = do
       logDebug args $ "handleStackConfig (cwd): " ++ cwd
       logDebug args $ "handleStackConfig (localDir): " ++ localDir
       logDebug args $ "handleStackConfig (remoteUri): " ++ show remoteUri
-      let stackFile = localDir </> "stack.yaml"
+      let stackFile = localDir </> argStackYaml
       alreadyExists <- doesFileExist stackFile
       unless alreadyExists $ error $ stackFile <> " does not exist. Use 'stack init' to create it."
       logDebug args $ "handleStackConfig (alreadyExists): " ++ show alreadyExists

--- a/src/Stack2nix/External/Stack.hs
+++ b/src/Stack2nix/External/Stack.hs
@@ -146,6 +146,7 @@ globalOpts currentDir stackRoot Args{..} =
                   , ["--jobs", show argThreads]
                   , ["--test" | argTest]
                   , ["--haddock" | argHaddock]
+                  , ["--stack-yaml", argStackYaml]
                   , ["--no-install-ghc"]
                   ]
     go = globalOptsFromMonoid False . fromJust . getParseResult $ execParserPure defaultPrefs pinfo args

--- a/src/Stack2nix/Types.hs
+++ b/src/Stack2nix/Types.hs
@@ -13,5 +13,6 @@ data Args = Args
   , argPlatform        :: Platform
   , argUri             :: String
   , argVerbose         :: Bool
+  , argStackYaml       :: String
   }
   deriving (Show)

--- a/stack2nix/Main.hs
+++ b/stack2nix/Main.hs
@@ -21,6 +21,7 @@ args = Args
        <*> option (readP platformReader) (long "platform" <> help "target platform to use when invoking stack or cabal2nix" <> value buildPlatform <> showDefaultWith display)
        <*> strArgument (metavar "URI")
        <*> switch (long "verbose" <> help "verbose output")
+       <*> strOption (long "stack-yaml" <> help "stack yaml file to parse" <> value "stack.yaml")
   where
     -- | A parser for the date. Hackage updates happen maybe once or twice a month.
     -- Example: parseTime defaultTimeLocale "%FT%T%QZ" "2017-11-20T12:18:35Z" :: Maybe UTCTime


### PR DESCRIPTION
Allows for smoother handling of projects with multiple stack.yaml files under different names, for example haskell-ide-engine.