### PR TITLE
Fail if cabal update fails

### DIFF
--- a/src/Stack2nix.hs
+++ b/src/Stack2nix.hs
@@ -13,7 +13,7 @@ import           Data.Maybe                 (isJust)
 import           Data.Monoid                ((<>))
 import           Paths_stack2nix            (version)
 import           Stack2nix.External.Stack
-import           Stack2nix.External.Util    (runCmdFrom)
+import           Stack2nix.External.Util    (runCmdFrom, failHard)
 import           Stack2nix.External.VCS.Git (Command (..), ExternalCmd (..),
                                              InternalCmd (..), git)
 import           Stack2nix.Types            (Args (..))
@@ -46,8 +46,10 @@ stack2nix args@Args{..} = do
     tryGit tmpDir >> handleStackConfig (Just argUri) tmpDir
   where
     updateCabalPackageIndex :: IO ()
-    updateCabalPackageIndex =
-      getEnv "HOME" >>= \home -> void $ runCmdFrom home "cabal" ["update"]
+    updateCabalPackageIndex = do
+      home <- getEnv "HOME"
+      out <- runCmdFrom home "cabal" ["update"]
+      void $ failHard out
 
     tryGit :: FilePath -> IO ()
     tryGit tmpDir = do

--- a/src/Stack2nix/External/Stack.hs
+++ b/src/Stack2nix/External/Stack.hs
@@ -6,7 +6,6 @@ module Stack2nix.External.Stack
   ( PackageRef(..), runPlan
   ) where
 
-import           Control.Applicative           ((<|>))
 import           Data.List                     (concat)
 import qualified Data.Map.Strict               as M
 import           Data.Maybe                    (fromJust)
@@ -112,7 +111,6 @@ runPlan baseDir remoteUri args@Args{..} = do
   ensureExecutable ("haskell.compiler.ghc" ++ ghcnixversion)
   withBuildConfig globals $ planAndGenerate buildOpts baseDir remoteUri args ghcnixversion
 
-
 getGhcVersionIO :: GlobalOpts -> FilePath -> IO (CompilerVersion 'CVWanted)
 getGhcVersionIO go stackFile = do
   cp <- canonicalizePath stackFile
@@ -121,13 +119,6 @@ getGhcVersionIO go stackFile = do
     -- https://www.fpcomplete.com/blog/2017/07/the-rio-monad
     runRIO runner $ loadConfig mempty Nothing (SYLOverride fp)
   loadCompilerVersion go lc
-
-{-
-  TODO:
-  - replace "ghc" in package list with value encoding compiler version
-  - handle custom shell.nix  (see mshellFile in Stack.Nix.runShellAndExit)
-  - remove baseDir arguments; due to withCurrentDirectory it should always be PWD.
--}
 
 globalOpts :: FilePath -> FilePath -> Args -> GlobalOpts
 globalOpts currentDir stackRoot Args{..} =


### PR DESCRIPTION
Example:

```
$ touch ~/.cabal/packages/hackage.haskell.org/hackage-security-lock
$ ~/.local/bin/stack2nix .                                                                 
Ensuring git version is >= 2 ...                               
Ensuring cabal version is >= 2 ...
stack2nix: Failed with exit code 1...                                       
"/home/ielectric/.cabal/packages/hackage.haskell.org/hackage-security-lock: createDirectory: already e
xists (File exists)"                                                       
                                                                                   
CallStack (from HasCallStack):                                             
  error, called at src/Stack2nix/External/Util.hs:21:3 in stack2nix-0.1.3.1-HwgtPF9ZM2W8vYBIr0JOPS:Sta
ck2nix.External.Util                                     
                                      
```

fixes #92 