### PR TITLE
Add flag to clone a git repository `recursive`

### DIFF
--- a/src/Stack2nix.hs
+++ b/src/Stack2nix.hs
@@ -56,9 +56,14 @@ stack2nix args@Args{..} = do
       let externalCmd = if argGitRecursive
                           then CloneRecursive argUri tmpDir
                           else Clone argUri tmpDir
-      void $ git $ OutsideRepo externalCmd
+      void . git $ OutsideRepo externalCmd
       case argRev of
-        Just r  -> void $ git $ InsideRepo tmpDir (Checkout r)
+        Just rev  ->
+          let internalCmd = if argGitRecursive
+                              then CheckoutRecursive rev 
+                              else Checkout rev
+          in
+            void . git $ InsideRepo tmpDir internalCmd
         Nothing -> return mempty
 
     handleStackConfig :: Maybe String -> FilePath -> IO ()

--- a/src/Stack2nix.hs
+++ b/src/Stack2nix.hs
@@ -53,7 +53,10 @@ stack2nix args@Args{..} = do
 
     tryGit :: FilePath -> IO ()
     tryGit tmpDir = do
-      void $ git $ OutsideRepo $ Clone argUri tmpDir
+      let externalCmd = if argGitRecursive
+                          then CloneRecursive argUri tmpDir
+                          else Clone argUri tmpDir
+      void $ git $ OutsideRepo externalCmd
       case argRev of
         Just r  -> void $ git $ InsideRepo tmpDir (Checkout r)
         Nothing -> return mempty

--- a/src/Stack2nix/External/VCS/Git.hs
+++ b/src/Stack2nix/External/VCS/Git.hs
@@ -6,11 +6,17 @@ module Stack2nix.External.VCS.Git
 import           Stack2nix.External.Util (failHard, runCmd, runCmdFrom)
 import           System.Exit             (ExitCode (..))
 
-data Command = OutsideRepo ExternalCmd
-             | InsideRepo FilePath InternalCmd
-data ExternalCmd = Clone String FilePath
+data Command
+  = OutsideRepo ExternalCmd
+  | InsideRepo FilePath InternalCmd
+
+data ExternalCmd
+  = Clone RepoUri FilePath
+  | CloneRecursive RepoUri FilePath
+
 data InternalCmd = Checkout CommitRef
 
+type RepoUri = String
 type CommitRef = String
 
 exe :: String
@@ -24,6 +30,8 @@ git (InsideRepo dir cmd) = runInternal dir cmd
 runExternal :: ExternalCmd -> IO (ExitCode, String, String)
 runExternal (Clone uri dir) =
   runCmd exe ["clone", uri, dir] >>= failHard
+runExternal (CloneRecursive uri dir) =
+  runCmd exe ["clone", uri, "--recursive", dir] >>= failHard
 
 runInternal :: FilePath -> InternalCmd -> IO (ExitCode, String, String)
 runInternal repoDir (Checkout ref) =

--- a/src/Stack2nix/Types.hs
+++ b/src/Stack2nix/Types.hs
@@ -14,5 +14,6 @@ data Args = Args
   , argPlatform        :: Platform
   , argUri             :: String
   , argVerbose         :: Bool
+  , argGitRecursive    :: Bool
   }
   deriving (Show)

--- a/stack2nix/Main.hs
+++ b/stack2nix/Main.hs
@@ -22,6 +22,7 @@ args = Args
        <*> option (readP platformReader) (long "platform" <> help "target platform to use when invoking stack or cabal2nix" <> value buildPlatform <> showDefaultWith display)
        <*> strArgument (metavar "URI")
        <*> switch (long "verbose" <> help "verbose output")
+       <*> switch (long "git-recursive" <> help "clone external git reposity w/ all submodules")
   where
     -- | A parser for the date. Hackage updates happen maybe once or twice a month.
     -- Example: parseTime defaultTimeLocale "%FT%T%QZ" "2017-11-20T12:18:35Z" :: Maybe UTCTime


### PR DESCRIPTION
to support `git` submodules.

I came across that issue while trying to update https://github.com/domenkozar/hie-nix to latest [`HIE`](https://github.com/haskell/haskell-ide-engine). Because `HIE` is [using submodules now](https://github.com/haskell/haskell-ide-engine/pull/526), `stack2nix` was thrown an error about missing sources of submodules defined in [`stack-8.2.1.yaml`](https://github.com/haskell/haskell-ide-engine/blob/master/stack-8.0.2.yaml) or  [`stack-8.2.1.yaml`](https://github.com/haskell/haskell-ide-engine/blob/master/stack-8.0.2.yaml).

This PR will fix that issue.