### PR TITLE
[DEVOPS-860] Add option to disable indentation

### DIFF
--- a/src/Stack2nix/PP.hs
+++ b/src/Stack2nix/PP.hs
@@ -1,0 +1,40 @@
+module Stack2nix.PP
+   (ppIndented, ppSingletons) where
+
+import           Text.PrettyPrint (Doc, Mode(..), TextDetails(..), fullRender, render)
+
+-- | Formats the derivation doc with indentation and lines wrapped at 100 chars.
+ppIndented :: Doc -> String
+ppIndented = render
+
+-- | Formats the derivation doc without indentation and with each list
+-- element and function argument on its own line.
+-- We go to this effort to "ugly-print" so that the resulting file is
+-- less susceptible to merge conflicts when checked into git.
+ppSingletons :: Doc -> String
+ppSingletons doc = fixSpace . snd $ fullRender LeftMode 80 1.5 printer (0, "") doc
+  where
+    printer :: TextDetails -> (Int, String) -> (Int, String)
+    printer (Chr c) (n, s) = ppChar n s c
+    printer (Str s1) s2    = fmap (s1 ++) s2
+    printer (PStr s1) s2   = fmap (s1 ++) s2
+
+    ppChar :: Int -> String -> Char -> (Int, String)
+    ppChar n s c = (n', s')
+      where
+        s' = case c of
+               ',' -> "\n," ++ s
+               ' ' -> (if n /= 0 then '\n' else ' '):s
+               '{' -> "{\n " ++ s
+               '}' -> "\n}" ++ s
+               _   -> c:s
+        n' = case c of
+               '[' -> n - 1  -- PrettyPrint works backwards
+               ']' -> n + 1
+               _   -> n
+
+    -- remove single trailing spaces
+    fixSpace :: String -> String
+    fixSpace (' ':'\n':s) = '\n':fixSpace s
+    fixSpace (c:s) = c:fixSpace s
+    fixSpace [] = []

--- a/src/Stack2nix/Types.hs
+++ b/src/Stack2nix/Types.hs
@@ -14,6 +14,7 @@ data Args = Args
   , argHackageSnapshot :: Maybe UTCTime
   , argPlatform        :: Platform
   , argUri             :: String
+  , argIndent          :: Bool
   , argVerbose         :: Bool
   }
   deriving (Show)

--- a/stack2nix.cabal
+++ b/stack2nix.cabal
@@ -40,9 +40,10 @@ library
                      , text >= 1.2.2.1 && < 1.3
                      , time
   exposed-modules:     Stack2nix
+                     , Stack2nix.PP
+                     , Stack2nix.Render
                      , Stack2nix.Types
                      , Stack2nix.Util
-                     , Stack2nix.Render
   other-modules:       Stack2nix.External.Cabal2nix
                      , Stack2nix.External.Stack
                      , Stack2nix.External.VCS.Git

--- a/stack2nix/Main.hs
+++ b/stack2nix/Main.hs
@@ -24,6 +24,7 @@ args = Args
        <*> optional (option utcTimeReader (long "hackage-snapshot" <> help "hackage snapshot time, ISO format"))
        <*> option (readP platformReader) (long "platform" <> help "target platform to use when invoking stack or cabal2nix" <> value buildPlatform <> showDefaultWith display)
        <*> strArgument (metavar "URI")
+       <*> flag True False (long "no-indent" <> help "disable indentation and place one item per line")
        <*> switch (long "verbose" <> help "verbose output")
   where
     -- | A parser for the date. Hackage updates happen maybe once or twice a month.


### PR DESCRIPTION
The `--no-indent` option puts each list item and function argument on its own line.

If the stack2nix result file is checked into git, this formatting option will result in less merge conflicts, or merge conflicts which are easier to resolve.
