### PR TITLE
Don't use `src = ./.` for stack2nix itself. See #119.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,17 @@ with pkgs.haskell.lib;
 ((import ./stack2nix.nix { inherit pkgs; }).override {
   overrides = self: super: {
     # TODO: separate out output
-    stack2nix = justStaticExecutables super.stack2nix;
+    stack2nix = justStaticExecutables (overrideCabal super.stack2nix (old: {
+        src = builtins.path {
+            name = "stack2nix";
+            path = ./.;
+            # Filter hidden dirs (.), e.g. .git and .stack-work
+            # TODO Remove once https://github.com/input-output-hk/stack2nix/issues/119 is done
+            filter = path: type:
+                !(pkgs.lib.hasPrefix "." (baseNameOf path))
+                && baseNameOf path != "stack.yaml";
+        };
+    }));
 
     # https://github.com/commercialhaskell/lts-haskell/issues/149
     stack = doJailbreak super.stack;


### PR DESCRIPTION
This is NOT the fix for #119; that one is about making stack2nix
generate fixes like this one, for all packages you run it on.