### PR TITLE
Fixing `nix-build` issue on OSX where `CoreServices` was not found.

### DIFF
--- a/stack2nix.nix
+++ b/stack2nix.nix
@@ -16478,7 +16478,7 @@ inherit (pkgs) libjpeg; inherit (pkgs) libpng; inherit (pkgs) zlib;};
            description = "File/folder watching for OS X";
            license = stdenv.lib.licenses.bsd3;
            platforms = [ "x86_64-darwin" ];
-         }) {inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;};
+         }) {inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa CoreServices;};
       "hidapi" = callPackage
         ({ mkDerivation, base, bytestring, deepseq, deepseq-generics
          , stdenv, systemd


### PR DESCRIPTION
Resolves the below error when building on OSX:

```
❯ nix-build
error: anonymous function at ~/Work/stack2nix/stack2nix.nix:16465:10 called without required argument 'CoreServices', at /nix/store/shm5fcq49wnwgjhpn4l05jzg53wm0h2b-nixpkgs-18.09pre151052.4477cf04b67/nixpkgs/pkgs/development/haskell-modules/make-package-set.nix:88:27
(use '--show-trace' to show detailed location information)
```

Note I also needed to override the `pkgs` value as I hit the clang to many arguments issue https://github.com/NixOS/nixpkgs/issues/41340 .

```
❯ nix-build --arg pkgs 'import <nixpkgs> {}'
```

