### PR TITLE
Allow extra cabal2nix args

### DIFF
--- a/src/Stack2nix/External/Cabal2nix.hs
+++ b/src/Stack2nix/External/Cabal2nix.hs
@@ -8,7 +8,7 @@ module Stack2nix.External.Cabal2nix (
 import           Cabal2nix                   (cabal2nixWithDB, parseArgs, optNixpkgsIdentifier, Options)
 import           Control.Lens
 import           Data.Bool                   (bool)
-import           Data.Maybe                  (fromMaybe)
+import           Data.Maybe                  (fromMaybe, maybeToList)
 import           Data.Text                   (Text, unpack)
 import qualified Distribution.Nixpkgs.Haskell.Hackage as DB
 import           Distribution.Nixpkgs.Haskell.Derivation (Derivation)
@@ -32,6 +32,7 @@ cabal2nix Args{..} ghcVersion uri commit subpath flags hackageDB = do
     args :: FilePath -> [String]
     args dir = concat
       [ maybe [] (\c -> ["--revision", unpack c]) commit
+      , maybeToList argCabal2nixArgs
       , ["--subpath", dir]
       , ["--system", fromCabalPlatform argPlatform]
       , ["--compiler", "ghc-" ++ show ghcVersion]

--- a/src/Stack2nix/Types.hs
+++ b/src/Stack2nix/Types.hs
@@ -17,6 +17,7 @@ data Args = Args
   , argUri             :: String
   , argIndent          :: Bool
   , argVerbose         :: Bool
+  , argCabal2nixArgs   :: Maybe String
   }
   deriving (Show)
 

--- a/stack2nix/Main.hs
+++ b/stack2nix/Main.hs
@@ -26,6 +26,7 @@ args = Args
        <*> strArgument (metavar "URI")
        <*> flag True False (long "no-indent" <> help "disable indentation and place one item per line")
        <*> switch (long "verbose" <> help "verbose output")
+       <*> optional (strOption $ long "cabal2nix-args" <> help "extra arguments for cabal2nix")
   where
     -- | A parser for the date. Hackage updates happen maybe once or twice a month.
     -- Example: parseTime defaultTimeLocale "%FT%T%QZ" "2017-11-20T12:18:35Z" :: Maybe UTCTime


### PR DESCRIPTION
This should allow e.g. to pass `--no-hpack` flag to `cabal2nix` so `hpack` won't be required when there's already a cabal (see https://github.com/NixOS/cabal2nix/pull/403 )