### PR TITLE
small fixes for running in nix-build

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## (next)
+
+Other enhancements:
+
+- When writing nix expressions to file (`-o` flag), force UTF-8 encoding #164
+- Add flag `--no-ensure-executables` to stop `stack2nix` from ensuring
+  necessary executables exist #164
+
 ## v0.2.2 (2019-01-17)
 
 Bug fixes:

--- a/src/Stack2nix.hs
+++ b/src/Stack2nix.hs
@@ -8,7 +8,7 @@ module Stack2nix
   , version
   ) where
 
-import           Control.Monad              (unless, void)
+import           Control.Monad              (unless, void, when)
 import           Data.Maybe                 (isJust)
 import           Data.Monoid                ((<>))
 import           Paths_stack2nix            (version)
@@ -26,9 +26,10 @@ import           System.IO.Temp             (withSystemTempDirectory)
 
 stack2nix :: Args -> IO ()
 stack2nix args@Args{..} = do
-  ensureExecutableExists "cabal" "cabal-install"
-  ensureExecutableExists "git" "git"
-  ensureExecutableExists "nix-prefetch-git" "nix-prefetch-scripts"
+  when argEnsureExecutables $ do
+    ensureExecutableExists "cabal" "cabal-install"
+    ensureExecutableExists "git" "git"
+    ensureExecutableExists "nix-prefetch-git" "nix-prefetch-scripts"
   assertMinVer "git" "2"
   assertMinVer "cabal" "2"
   setEnv "GIT_QUIET" "y"

--- a/src/Stack2nix/External/Stack.hs
+++ b/src/Stack2nix/External/Stack.hs
@@ -7,6 +7,7 @@ module Stack2nix.External.Stack
   ) where
 
 import           Control.Lens                                   ((%~))
+import           Control.Monad                                  (when)
 import           Data.List                                      (concat)
 import qualified Data.Map.Strict                                as M
 import           Data.Maybe                                     (fromJust)
@@ -156,7 +157,8 @@ runPlan baseDir remoteUri args@Args{..} = do
   let stackFile = baseDir </> argStackYaml
 
   ghcVersion <- getGhcVersionIO globals stackFile
-  ensureExecutable ("haskell.compiler.ghc" ++ nixVersion ghcVersion)
+  when argEnsureExecutables $
+    ensureExecutable ("haskell.compiler.ghc" ++ nixVersion ghcVersion)
   withBuildConfig globals $ planAndGenerate buildOpts baseDir remoteUri args ghcVersion
 
 nixVersion :: Version -> String

--- a/src/Stack2nix/Render.hs
+++ b/src/Stack2nix/Render.hs
@@ -8,12 +8,15 @@ module Stack2nix.Render
 
 import           Control.Lens
 import           Control.Monad                           (when)
+import qualified Data.ByteString                         as BS
 import           Data.Either                             (lefts, rights)
 import           Data.List                               (filter, isPrefixOf,
                                                           sort)
 import           Data.Monoid                             ((<>))
 import           Data.Set                                (Set)
 import qualified Data.Set                                as Set
+import qualified Data.Text                               as Text
+import           Data.Text.Encoding                      (encodeUtf8)
 import           Distribution.Nixpkgs.Haskell.BuildInfo  (haskell, pkgconfig,
                                                           system, tool)
 import           Distribution.Nixpkgs.Haskell.Derivation (Derivation,
@@ -86,7 +89,7 @@ render results args locals ghcnixversion = do
    let out = defaultNix pp ghcnixversion $ renderedMissing ++ map (renderOne args locals) drvs
 
    case argOutFile args of
-     Just fname -> writeFile fname out
+     Just fname -> BS.writeFile fname (encodeUtf8 $ Text.pack out)
      Nothing    -> putStrLn out
 
 renderOne :: Args -> [String] -> Derivation -> Doc

--- a/src/Stack2nix/Types.hs
+++ b/src/Stack2nix/Types.hs
@@ -5,19 +5,20 @@ import           Distribution.PackageDescription (FlagName)
 import           Distribution.System             (Platform)
 
 data Args = Args
-  { argRev             :: Maybe String
-  , argOutFile         :: Maybe FilePath
-  , argStackYaml       :: FilePath
-  , argThreads         :: Int
-  , argTest            :: Bool
-  , argBench           :: Bool
-  , argHaddock         :: Bool
-  , argHackageSnapshot :: Maybe UTCTime
-  , argPlatform        :: Platform
-  , argUri             :: String
-  , argIndent          :: Bool
-  , argVerbose         :: Bool
-  , argCabal2nixArgs   :: Maybe String
+  { argRev                 :: Maybe String
+  , argOutFile             :: Maybe FilePath
+  , argStackYaml           :: FilePath
+  , argThreads             :: Int
+  , argTest                :: Bool
+  , argBench               :: Bool
+  , argHaddock             :: Bool
+  , argHackageSnapshot     :: Maybe UTCTime
+  , argPlatform            :: Platform
+  , argUri                 :: String
+  , argIndent              :: Bool
+  , argVerbose             :: Bool
+  , argCabal2nixArgs       :: Maybe String
+  , argEnsureExecutables   :: Bool
   }
   deriving (Show)
 

--- a/stack2nix.cabal
+++ b/stack2nix.cabal
@@ -22,6 +22,7 @@ library
   build-depends:       base >=4.9 && <4.13
                      , Cabal >= 2.0.0.2 && < 2.5
                      , async >= 2.1.1.1 && < 2.3
+                     , bytestring
                      , cabal2nix >= 2.10
                      , containers >= 0.5.7.1 && < 0.7
                      , directory >= 1.3 && < 1.4

--- a/stack2nix.nix
+++ b/stack2nix.nix
@@ -31392,8 +31392,8 @@ inherit (pkgs) libjpeg; inherit (pkgs) libpng; inherit (pkgs) zlib;};
            license = stdenv.lib.licenses.bsd3;
          }) {};
       "stack2nix" = callPackage
-        ({ mkDerivation, async, base, Cabal, cabal2nix, containers
-         , directory, distribution-nixpkgs, filepath, hackage-db
+        ({ mkDerivation, async, base, bytestring, Cabal, cabal2nix
+         , containers, directory, distribution-nixpkgs, filepath, hackage-db
          , language-nix, lens, optparse-applicative, path, pretty, process
          , regex-pcre, SafeSemaphore, stack, stdenv, temporary, text, time
          }:
@@ -31405,7 +31405,7 @@ inherit (pkgs) libjpeg; inherit (pkgs) libpng; inherit (pkgs) zlib;};
            isLibrary = true;
            isExecutable = true;
            libraryHaskellDepends = [
-             async base Cabal cabal2nix containers directory
+             async base bytestring Cabal cabal2nix containers directory
              distribution-nixpkgs filepath hackage-db language-nix lens
              optparse-applicative path pretty process regex-pcre SafeSemaphore
              stack temporary text time

--- a/stack2nix/Main.hs
+++ b/stack2nix/Main.hs
@@ -27,6 +27,7 @@ args = Args
        <*> flag True False (long "no-indent" <> help "disable indentation and place one item per line")
        <*> switch (long "verbose" <> help "verbose output")
        <*> optional (strOption $ long "cabal2nix-args" <> help "extra arguments for cabal2nix")
+       <*> flag True False (long "no-ensure-executables" <> help "do not ensure required executables are installed")
   where
     -- | A parser for the date. Hackage updates happen maybe once or twice a month.
     -- Example: parseTime defaultTimeLocale "%FT%T%QZ" "2017-11-20T12:18:35Z" :: Maybe UTCTime


### PR DESCRIPTION
I'd like to create a nix derivation that runs `stack2nix` and creates a `.nix` file of a Haskell package set that can be imported with IFD.

I have something that is more-or-less working, but I needed two small changes in `stack2nix`.  These two changes are implemented in this PR:

1. In cb05818, I make sure that the output nix file is written with a UTF-8 encoding.  When running `stack2nix` in `nix-build`, I was seeing weird encoding-related run-time errors.  I didn't really dig into this, assuming it was just a result of [Beware of `writeFile`](https://www.snoyman.com/blog/2016/12/beware-of-readfile)].

    I changed this to make sure the file is output in UTF-8.  This is slightly different from how it currently works, but I figured this is a little safer.  If someone really wanted the file in a separate encoding, it is probably safer to convert from UTF-8 after running `stack2nix`.

2. In 2ccfe2b, I added an option to not make sure the required executables exist.  There is two reasons for making this change.  First, when running from within `nix-build`, we're completely in control of the environment, so we can be sure the required executables will exist.  Second, the way the `stack2nix` code is currently written, if the required executables don't exist, then `stack2nix` tries to use `nix-build` to install them.  However, `nix-build` can't be called from within `nix-build`, so this will always fail.

It'd also be great to get a release of `stack2nix` on Hackage with this PR, so I can try to get my nix function upstreamed in nixpkgs.