### PR TITLE
Report nix-build error message on failure

### DIFF
--- a/src/Stack2nix/Util.hs
+++ b/src/Stack2nix/Util.hs
@@ -76,4 +76,4 @@ ensureExecutable nixAttr = do
       hPutStrLn stderr $ err2
       path <- getEnv "PATH"
       setEnv "PATH" (unpack (strip (pack stdout)) ++ "/bin" ++ ":" ++ path)
-    ExitFailure _ -> error $ nixAttr ++ " failed to build via nix"
+    ExitFailure _ -> error $ nixAttr ++ " failed to build via nix:\n" ++ err2


### PR DESCRIPTION
This includes the stderr of nix-build in the error message on failure, which typically contains the error message.